### PR TITLE
Fixed Raycaster

### DIFF
--- a/three.d.ts
+++ b/three.d.ts
@@ -2032,8 +2032,7 @@ module THREE {
 
     export class Raycaster {
         constructor(origin?: Vector3, direction?: Vector3, near?: number, far?: number);
-        origin: Vector3;
-        direction: Vector3;
+        ray: Ray;
         near: number;
         far: number;
         precision: number;


### PR DESCRIPTION
https://github.com/mrdoob/three.js/blob/master/src/core/Raycaster.js

The documentation claims `origin` and `direction` are there, but they are not.
